### PR TITLE
With out the .all() method, the queryset will be evaluated lazily

### DIFF
--- a/INSIGHTSAPI/goals/views.py
+++ b/INSIGHTSAPI/goals/views.py
@@ -1,5 +1,4 @@
 import logging
-from simple_history.models import HistoricalRecords
 import os
 import re
 from django.utils import timezone
@@ -42,7 +41,8 @@ class GoalsViewSet(viewsets.ModelViewSet):
             )
             return unique_goals
         else:
-            return self.queryset
+            # With out the .all() method, the queryset will be evaluated lazily
+            return self.queryset.all()
 
     @action(detail=False, methods=['post'])
     def send_email(self, request, *args, **kwargs):

--- a/INSIGHTSAPI/users/tests.py
+++ b/INSIGHTSAPI/users/tests.py
@@ -30,62 +30,35 @@ class LDAPAuthenticationTest(TestCase):
             if conn:
                 conn.unbind()
 
-    def test_login_ldap3(self):
-            ldap_server_uri = settings.AUTH_LDAP_SERVER_URI
-            ldap_bind_dn = settings.AUTH_LDAP_BIND_DN
-            ldap_bind_password = settings.AUTH_LDAP_BIND_PASSWORD
-            username = "heibert.mogollon"
-            password = "Password3"
-            conn = None
-            try:
-                with Connection(Server(ldap_server_uri, get_info=ALL),user=ldap_bind_dn,password=ldap_bind_password,authentication=SIMPLE) as conn:
-                    conn.bind()
-                    user_entry = conn.search(
-                        search_base="dc=CYC-SERVICES,dc=COM,dc=CO",
-                        search_filter=f"(sAMAccountName={username})",
-                        search_scope=SUBTREE,
-                        attributes='CN'
-                    )
-                    self.assertTrue(user_entry, "User entry not found.")
-                    if user_entry and conn.response:
-                        user = conn.response[0]['dn']
-                        conn.rebind(user=user, password=password)
-                        self.assertTrue(conn.bound, "User authentication failed.")
-            except Exception as e:
-                self.fail("Error: %s" % e)
-            finally:
-                if conn:
-                    conn.unbind()
-
-    def test_login(self):
-        ldap_server_uri = settings.AUTH_LDAP_SERVER_URI
-        ldap_bind_dn = settings.AUTH_LDAP_BIND_DN
-        ldap_bind_password = settings.AUTH_LDAP_BIND_PASSWORD
-        username = "heibert.mogollon"
-        password = "Password3"
-        conn = None
-        try:
-            conn = ldap.initialize(ldap_server_uri)
-            conn.simple_bind_s(ldap_bind_dn, ldap_bind_password)
-            search_filter = "(sAMAccountName={})".format(username)
-            search_base = "dc=CYC-SERVICES,dc=COM,dc=CO"
-            attributes = ['dn']
-            result_id = conn.search(search_base, ldap.SCOPE_SUBTREE, search_filter, attributes)
-            result_type, result_data = conn.result(result_id, 0)
-            self.assertTrue(result_data, "User entry not found.")
-            if result_data:
-                user_dn = result_data[0][0]
-                loged = conn.simple_bind_s(user_dn, password)
-                self.assertTrue(loged, "User authentication failed.")
-        except ldap.LDAPError as e:
-            self.fail("Error: %s" % e)
-        finally:
-            if conn:
-                conn.unbind()
+    # def test_login(self):
+    #     ldap_server_uri = settings.AUTH_LDAP_SERVER_URI
+    #     ldap_bind_dn = settings.AUTH_LDAP_BIND_DN
+    #     ldap_bind_password = settings.AUTH_LDAP_BIND_PASSWORD
+    #     username = "heibert.mogollon"
+    #     password = "Password4"
+    #     conn = None
+    #     try:
+    #         conn = ldap.initialize(ldap_server_uri)
+    #         conn.simple_bind_s(ldap_bind_dn, ldap_bind_password)
+    #         search_filter = "(sAMAccountName={})".format(username)
+    #         search_base = "dc=CYC-SERVICES,dc=COM,dc=CO"
+    #         attributes = ['dn']
+    #         result_id = conn.search(search_base, ldap.SCOPE_SUBTREE, search_filter, attributes)
+    #         result_type, result_data = conn.result(result_id, 0)
+    #         self.assertTrue(result_data, "User entry not found.")
+    #         if result_data:
+    #             user_dn = result_data[0][0]
+    #             loged = conn.simple_bind_s(user_dn, password)
+    #             self.assertTrue(loged, "User authentication failed.")
+    #     except ldap.LDAPError as e:
+    #         self.fail("Error: %s" % e)
+    #     finally:
+    #         if conn:
+    #             conn.unbind()
 
     def test_login_django(self):
         username = "heibert.mogollon"
-        password = "Password3"
+        password = "Password4"
         request = RequestFactory().get('/mock-url')
         # Authenticate using the LDAP backend
         ldap_backend = LDAPBackend()


### PR DESCRIPTION
Commented test ldap redundant