### PR TITLE
Add functionality to edit paid days for vacations

### DIFF
--- a/frontend/src/components/pages/vacations/Vacations.jsx
+++ b/frontend/src/components/pages/vacations/Vacations.jsx
@@ -62,6 +62,9 @@ export const Vacations = () => {
     const [vacationId, setVacationId] = useState();
     const [openObservationsInput, setOpenObservationsInput] = useState(false);
     const observationsRef = useRef();
+    const [openEditPaidDays, setOpenEditPaidDays] = useState(false);
+    const [paidDaysValue, setPaidDaysValue] = useState('');
+    const [editingVacationId, setEditingVacationId] = useState(null);
     const cargo = localStorage.getItem('cargo');
     const rank = JSON.parse(localStorage.getItem('rango'));
     const cedula = JSON.parse(localStorage.getItem('cedula'));
@@ -681,6 +684,51 @@ export const Vacations = () => {
         setOpenDialogPayslip(true);
         setVacationId(id);
         setApprovalType(approvalType);
+    };
+
+    const handleEditPaidDays = async (event) => {
+        event.preventDefault();
+        showProgressbar();
+
+        const formData = new FormData();
+        formData.append('paid_days', paidDaysValue);
+
+        try {
+            const response = await fetch(
+                `${getApiUrl().apiUrl}vacation/${editingVacationId}/`,
+                {
+                    method: 'PATCH',
+                    credentials: 'include',
+                    body: formData,
+                }
+            );
+
+            await handleError(response, showSnack);
+
+            if (response.status === 200) {
+                getVacations();
+                showSnack('success', 'Días pagados actualizados correctamente');
+                handleCloseEditPaidDays();
+            }
+        } catch (error) {
+            if (getApiUrl().environment === 'development') {
+                console.error(error);
+            }
+        } finally {
+            hideProgressbar();
+        }
+    };
+
+    const handleOpenEditPaidDays = (id, currentPaidDays) => {
+        setEditingVacationId(id);
+        setPaidDaysValue(currentPaidDays || '');
+        setOpenEditPaidDays(true);
+    };
+
+    const handleCloseEditPaidDays = () => {
+        setOpenEditPaidDays(false);
+        setEditingVacationId(null);
+        setPaidDaysValue('');
     };
 
     return (


### PR DESCRIPTION
- Introduced state management for editing paid days, including handling form submission and API interaction.
- Added methods to open and close the edit paid days modal, enhancing user experience for vacation management.